### PR TITLE
patch4: remove testcases except the ones having certain Xray related properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,49 @@ becomes...
     </testcase>
 ```
 
+### Patch 4
+
+This patch removes all `testcase` elements, except the ones that have a `property` with `name` "requirements" or "test_key". These properties are usually provided by the xray-junit-extensions project to provide more info on the tests that Xray Test Management will consume.
+
+For example, the first `testcase` will be included while the second one won't.
+
+```xml
+    <testcase name="Test login page @CALC-1" classname="specs/tags.spec.mjs:3:1 › Test login page @CALC-1" time="3.767">
+        <properties>
+            <property name="test_key" value="CALC-2">
+            </property>
+            <property name="requirements" value="CALC-5">
+            </property>
+        </properties>
+        <system-out>
+            <![CDATA[
+        [[ATTACHMENT|test-results/specs-tags-Test-login-page-CALC-1/tmp_screenshot.png]]
+        ]]>
+        </system-out>
+    </testcase>
+
+    <testcase name="Invoice" time="18" classname="FleetApp">
+    </testcase>
+```
+
+After the patch, it becomes...
+
+```xml
+    <testcase name="Test login page @CALC-1" classname="specs/tags.spec.mjs:3:1 › Test login page @CALC-1" time="3.767">
+        <properties>
+            <property name="test_key" value="CALC-2">
+            </property>
+            <property name="requirements" value="CALC-5">
+            </property>
+        </properties>
+        <system-out>
+            <![CDATA[
+        [[ATTACHMENT|test-results/specs-tags-Test-login-page-CALC-1/tmp_screenshot.png]]
+        ]]>
+        </system-out>
+    </testcase>
+```
+
 ## Contributing
 
 Feel free to submit issues and/or PRs! In lieu of a formal style guide,  please follow existing styles.

--- a/lib/index.js
+++ b/lib/index.js
@@ -107,6 +107,8 @@ function handle(options) {
 					applyPatch2(data);
 				} else if (patchNumber === '3') {
 					applyPatch3(data);
+				} else if (patchNumber === '4') {
+					applyPatch4(data);
 				}
 			}
 		}
@@ -192,6 +194,45 @@ function applyPatch3(data) {
 					testcase.failure[0]['_'] = failureMessage;
 				}
 			}
+		}
+	}
+}
+
+// keep just the testcases with properties having the names "test_key" or "requirement"
+function applyPatch4(data) {
+	// iterate over testsuite elements
+	var testsuites =  [ (data.testsuites ? data.testsuites.testsuite : data.testsuite) ].flat();
+	for (var suite of testsuites) {
+		// iterate over testcases and apply patch
+		for (var testcase of Array.from(suite.testcase)) {
+			var index = 0;
+			var keep_testcase = false;
+			if (testcase.properties) {
+				/*
+				console.log("####################");
+				console.log(testcase.properties[0].property);
+				console.log("####################");
+				*/
+				var properties =  Array.from(testcase.properties[0].property);
+				if (properties.length > 0) {
+					for (var property of properties) {
+						/*
+						console.log('=====================');
+						console.log(property['$'].name);
+						console.log('=====================');
+						*/
+
+						if ((property['$'].name === 'test_key') || (property['$'].name === 'requirements'))  {
+							keep_testcase = true;
+						}
+					}
+				}
+			}
+
+			if (!keep_testcase) {
+				suite.testcase.splice(index, 1);
+			}
+			index++;
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "junit-processor",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "A JUnit XML post processing utility, for cleanup and similar purposes",
   "main": "index.js",
   "bin": "./bin/junit-processor",

--- a/test/fixtures/4.xml
+++ b/test/fixtures/4.xml
@@ -1,5 +1,5 @@
-<testsuites id="" name="" tests="5" failures="0" skipped="2" errors="0" time="4.238">
-<testsuite name="specs/example.spec.mjs" timestamp="1642088240147" hostname="" tests="4" failures="0" skipped="2" time="3.792" errors="0">
+<testsuites id="" name="" tests="6" failures="0" skipped="2" errors="0" time="4.238">
+<testsuite name="specs/example.spec.mjs" timestamp="1642088240147" hostname="" tests="3" failures="0" skipped="2" time="3.792" errors="0">
 <testcase name="basic test" classname="specs/example.spec.mjs:17:1 › basic test" time="3.559">
 <system-out>
 <![CDATA[Finished basic test with status passed
@@ -17,6 +17,10 @@
 <testcase name="with failure" classname="specs/example.spec.mjs:28:1 › with failure" time="0.106">
 <failure>
 </failure>
+<properties>
+<property name="requirements" value="CALC-5">
+</property>
+</properties>
 </testcase>
 </testsuite>
 <testsuite name="specs/tags.spec.mjs" timestamp="1642088240147" hostname="" tests="2" failures="0" skipped="0" time="3.876" errors="0">
@@ -34,6 +38,10 @@
 </system-out>
 </testcase>
 <testcase name="Test full report @slow" classname="specs/tags.spec.mjs:15:1 › Test full report @slow" time="0.109">
+<properties>
+<property name="test_key" value="CALC-6">
+</property>
+</properties>
 </testcase>
 </testsuite>
 </testsuites>

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -156,6 +156,25 @@ describe("patches", function() {
         xml.testsuites.testsuite[0].testcase[0].failure[0]['$'].message.should.equal("multiple failures");
         xml.testsuites.testsuite[0].testcase[0].failure[0]['_'].should.equal('The property checkpoint failed, because Text does not equal (case-sensitive) "150.0". See Details for additional information.\nx1\nThe test run has stopped because the test item is configured to stop on errors.\n');
       });
+
+
+      it("patch 4 - should keep just the testcases with properties having the names test_key or requirement", function() {
+        const options = {
+            inputFile: './test/fixtures/4.xml',
+            patches: [ '4' ]
+        };
+        var res = junitXmlProcessor.handle(options);
+
+        var xml = parseXMLString(res);
+        // xml.testsuites['$'].tests.should.equal("3");
+        // xml.testsuites.testsuite[0]['$'].tests.should.equal("3");
+
+        xml.testsuites.testsuite[0].testcase.length.should.equal(1);
+        xml.testsuites.testsuite[0].testcase[0]['$'].name.should.equal("with failure");
+        xml.testsuites.testsuite[1].testcase.length.should.equal(2);
+        xml.testsuites.testsuite[1].testcase[0]['$'].name.should.equal("Test login page @CALC-1");
+        xml.testsuites.testsuite[1].testcase[1]['$'].name.should.equal('Test full report @slow');
+      });
 });
 
 describe("XML schema validation", function() {


### PR DESCRIPTION
removes all testcases except if they have `property` elements with  `name` attribute of  `test_key` or `requirements`.